### PR TITLE
Fix for GCC compiler on ubuntu 18.04

### DIFF
--- a/inc/Helpers.h
+++ b/inc/Helpers.h
@@ -26,7 +26,7 @@ string expand_path(const string& path);
 vector<string> split_string(const string& argString, char delimiter);
 bool file_exists(const std::string& name);
 
-inline constexpr bool str_contains(const std::string& str, const std::string& substr)
+inline bool str_contains(const std::string& str, const std::string& substr)
 {
   return (str.find(substr) != string::npos);
 }

--- a/inc/PlottingFramework.h
+++ b/inc/PlottingFramework.h
@@ -18,6 +18,11 @@
 #define PlottingFramework_h
 
 #include <iostream>
+#include <map>
+#include <set>
+#include <variant>
+#include <cmath>
+#include <cstdint>
 #include <boost/property_tree/ptree.hpp>
 #include <unordered_map>
 


### PR DESCRIPTION
- Added includes for cmath, set, and map
- Removed constexpr for str_contains