### PR TITLE
add TCandle support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
 endif()
 
 # The following two lines can be used to force using one specific root installation
-set(ROOTSYS ~/rootbuild)
+set(ROOTSYS ~/root/mybuild)
 list(APPEND CMAKE_PREFIX_PATH ${ROOTSYS})
 
 set(REQUIRED_ROOT_VERSION 6.16)

--- a/inc/Plot.h
+++ b/inc/Plot.h
@@ -22,6 +22,7 @@
 #include "TAttMarker.h"
 #include "TAttLine.h"
 #include "TAttFill.h"
+#include "TCandle.h"
 #include "Rtypes.h"
 
 #include "PlottingFramework.h"
@@ -60,6 +61,13 @@ enum drawing_options_t : uint8_t {
   colz,
   surf,
   cont,
+  candle1,
+  candle2,
+  candle3,
+  candle4,
+  candle5,
+  candle6,
+  candle7,
 };
 
 //**************************************************************************************************
@@ -206,6 +214,8 @@ public:
   Pad& SetDefaultDrawingOptionGraph(drawing_options_t drawingOption);
   Pad& SetDefaultDrawingOptionHist(drawing_options_t drawingOption);
   Pad& SetDefaultDrawingOptionHist2d(drawing_options_t drawingOption);
+  Pad& SetDefaultCandleBoxRange(float_t candleOption);
+  Pad& SetDefaultCandleWhiskerRange(float_t candleOption);
   Pad& SetFill(int16_t color, optional<int16_t> style = std::nullopt, optional<float_t> opacity = std::nullopt);
   Pad& SetFillColor(int16_t color);
   Pad& SetFillStyle(int16_t style);
@@ -272,6 +282,8 @@ protected:
   const auto& GetDefaultDrawingOptionGraph() const { return mDrawingOptionDefaults.graph; }
   const auto& GetDefaultDrawingOptionHist() const { return mDrawingOptionDefaults.hist; }
   const auto& GetDefaultDrawingOptionHist2d() const { return mDrawingOptionDefaults.hist2d; }
+  const auto& GetDefaultCandleBoxRange() const { return mCandleOptionDefaults.boxRange; }
+  const auto& GetDefaultCandleWhiskerRange() const { return mCandleOptionDefaults.whiskerRange; }
   const auto& GetRedrawAxes() const { return mRedrawAxes; }
   const auto& GetRefFunc() const { return mRefFunc; }
 
@@ -304,6 +316,10 @@ private:
     optional<drawing_options_t> hist;
     optional<drawing_options_t> hist2d;
   };
+  struct candle_defaults_t {
+    optional<double_t> boxRange;
+    optional<double_t> whiskerRange;
+  };
 
   // properties
   optional<string> mOptions;
@@ -319,6 +335,7 @@ private:
   view_defaults_t mLineDefaults;
   view_defaults_t mFillDefaults;
   data_defaults_t mDrawingOptionDefaults;
+  candle_defaults_t mCandleOptionDefaults;
 
   optional<int32_t> mPalette;
 

--- a/inc/PlotPainter.h
+++ b/inc/PlotPainter.h
@@ -46,6 +46,13 @@ const map<drawing_options_t, string> defaultDrawingOptions_Hist2d{
   {surf, "SURF"},
   {cont, "CONT3"},
   {text, "TEXT"},
+  {candle1, "CANDLEX1"},
+  {candle2, "CANDLEX2"},
+  {candle3, "CANDLEX3"},
+  {candle4, "CANDLEX4"},
+  {candle5, "CANDLEX5"},
+  {candle6, "CANDLEX6"},
+  {candle7, "CANDLEX(111101)"},                                                 //no median but mean as line
 };
 
 const map<drawing_options_t, string> defaultDrawingOptions_Hist{

--- a/src/Plot.cxx
+++ b/src/Plot.cxx
@@ -513,6 +513,28 @@ auto Plot::Pad::SetDefaultDrawingOptionHist2d(drawing_options_t drawingOption) -
 
 //**************************************************************************************************
 /**
+ * Set default box range option for 2d candle plot.
+ */
+//**************************************************************************************************
+auto Plot::Pad::SetDefaultCandleBoxRange(float_t candleOption) -> decltype(*this)
+{
+  mCandleOptionDefaults.boxRange = candleOption;
+  return *this;
+}
+
+//**************************************************************************************************
+/**
+ * Set default whisker range option for 2d candle plot.
+ */
+//**************************************************************************************************
+auto Plot::Pad::SetDefaultCandleWhiskerRange(float_t candleOption) -> decltype(*this)
+{
+  mCandleOptionDefaults.whiskerRange = candleOption;
+  return *this;
+}
+
+//**************************************************************************************************
+/**
  * Set fill for this pad.
  */
 //**************************************************************************************************
@@ -730,6 +752,8 @@ Plot::Pad::Pad(const ptree& padTree)
   read_from_tree(padTree, mDrawingOptionDefaults.graph, "default_drawing_option_graph");
   read_from_tree(padTree, mDrawingOptionDefaults.hist, "default_drawing_option_hist");
   read_from_tree(padTree, mDrawingOptionDefaults.hist2d, "default_drawing_option_hist2d");
+  read_from_tree(padTree, mCandleOptionDefaults.boxRange, "default_candle_option_boxrange");
+  read_from_tree(padTree, mCandleOptionDefaults.whiskerRange, "default_candle_option_whiskerrange");
   read_from_tree(padTree, mRedrawAxes, "redraw_axes");
   read_from_tree(padTree, mRefFunc, "ref_func");
 
@@ -811,6 +835,8 @@ ptree Plot::Pad::GetPropertyTree() const
   put_in_tree(padTree, mDrawingOptionDefaults.graph, "default_drawing_option_graph");
   put_in_tree(padTree, mDrawingOptionDefaults.hist, "default_drawing_option_hist");
   put_in_tree(padTree, mDrawingOptionDefaults.hist2d, "default_drawing_option_hist2d");
+  put_in_tree(padTree, mCandleOptionDefaults.boxRange, "default_candle_option_boxrange");
+  put_in_tree(padTree, mCandleOptionDefaults.whiskerRange, "default_candle_option_whiskerrange");
   put_in_tree(padTree, mRedrawAxes, "redraw_axes");
   put_in_tree(padTree, mRefFunc, "ref_func");
 
@@ -907,6 +933,8 @@ void Plot::Pad::operator+=(const Pad& pad)
   if (pad.mDrawingOptionDefaults.graph) mDrawingOptionDefaults.graph = pad.mDrawingOptionDefaults.graph;
   if (pad.mDrawingOptionDefaults.hist) mDrawingOptionDefaults.hist = pad.mDrawingOptionDefaults.hist;
   if (pad.mDrawingOptionDefaults.hist2d) mDrawingOptionDefaults.hist2d = pad.mDrawingOptionDefaults.hist2d;
+  if (pad.mCandleOptionDefaults.boxRange) mCandleOptionDefaults.boxRange = pad.mCandleOptionDefaults.boxRange;
+  if (pad.mCandleOptionDefaults.whiskerRange) mCandleOptionDefaults.whiskerRange = pad.mCandleOptionDefaults.whiskerRange;
   if (pad.mPalette) mPalette = pad.mPalette;
   if (pad.mRedrawAxes) mRedrawAxes = pad.mRedrawAxes;
   if (pad.mRefFunc) mRefFunc = pad.mRefFunc;

--- a/src/PlotManager.cxx
+++ b/src/PlotManager.cxx
@@ -480,6 +480,9 @@ bool PlotManager::GeneratePlot(const Plot& plot, const string& outputMode)
   }
   gSystem->Exec((string("mkdir -p ") + folderName).data());
   canvas->SaveAs(fullName.data());
+  // reset TCandle range options to their default values after drawing data
+  TCandle::SetBoxRange(0.5);
+  TCandle::SetWhiskerRange(0.75);
   return true;
 }
 

--- a/src/PlotPainter.cxx
+++ b/src/PlotPainter.cxx
@@ -199,6 +199,8 @@ unique_ptr<TCanvas> PlotPainter::GeneratePlot(Plot& plot, const unordered_map<st
     if (auto& frameBorderColor = get_first(pad.GetFrameBorderColor(), padDefaults.GetFrameBorderColor())) pad_ptr->SetFrameLineColor(*frameBorderColor);
     if (auto& frameBorderStyle = get_first(pad.GetFrameBorderStyle(), padDefaults.GetFrameBorderStyle())) pad_ptr->SetFrameLineStyle(*frameBorderStyle);
     if (auto& frameBorderWidth = get_first(pad.GetFrameBorderWidth(), padDefaults.GetFrameBorderWidth())) pad_ptr->SetFrameLineWidth(*frameBorderWidth);
+    if (auto& candleBoxRange = get_first(pad.GetDefaultCandleBoxRange(), padDefaults.GetDefaultCandleBoxRange())) TCandle::SetBoxRange(*candleBoxRange);
+    if (auto& candleWhiskerRange = get_first(pad.GetDefaultCandleWhiskerRange(), padDefaults.GetDefaultCandleWhiskerRange())) TCandle::SetWhiskerRange(*candleWhiskerRange);
 
     if (pad.GetDefaultMarkerColorsGradient().rgbEndpoints) {
       auto& gradient = pad.GetDefaultMarkerColorsGradient();


### PR DESCRIPTION
- added different TCandle drawing options for TH2
- added SetDefaultCandleBoxRange and SetDefaultCandleWhiskerRange on Pad level to change the box and whisker range for TCandle plots

**Quick Fix for TCandle Range Reset**
- changed variable name to camel case
- changed position of reset of TCandle range options to their default values after drawing data to the end of PlotManager::GeneratePlot
- Switch #include "TCandle.h" into Plot.h