### PR TITLE
Fix cmake warning for all capital find_package

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
 endif()
 
 list(PREPEND CMAKE_PREFIX_PATH ${SCIROOPLOT_ROOT})
-find_package(SciRooPlot CONFIG REQUIRED)
+find_package(SCIROOPLOT CONFIG REQUIRED)
 
 if(NOT EXISTS "${SCIROOPLOT_LIB}")
   message(FATAL_ERROR "Did not find SciRooPlot in ${SCIROOPLOT_ROOT}. Please source the .plotrc file or specify the correct path via -DSCIROOPLOT_ROOT=/path/to/SciRooPlot.")

--- a/skeleton/CMakeLists.txt
+++ b/skeleton/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
 endif()
 
 list(PREPEND CMAKE_PREFIX_PATH ${SCIROOPLOT_ROOT})
-find_package(SciRooPlot CONFIG REQUIRED)
+find_package(SCIROOPLOT CONFIG REQUIRED)
 
 if(NOT EXISTS "${SCIROOPLOT_LIB}")
   message(FATAL_ERROR "Did not find SciRooPlot in ${SCIROOPLOT_ROOT}. Please source the .plotrc file or specify the correct path via -DSCIROOPLOT_ROOT=/path/to/SciRooPlot.")


### PR DESCRIPTION
- With the newest version of cmake the find_package function expects all capital arguments. This change is only important for the skeleton task for SciRooPlot -> SCIROOPLOT
- Users will need to adjust this in their existing created tasks!